### PR TITLE
Large-Data Unit tests for all protocols

### DIFF
--- a/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/Delimiter.cs
+++ b/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/Delimiter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,12 +52,12 @@ namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x=>x == 100));
-            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 128).ToArray());
-            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 128).ToArray());
-            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 128).ToArray());
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 8).ToArray());
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 8).ToArray());
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 8).ToArray());
 
-            await TestHelper.WaitWhileFalse(() => receivedBytes == ushort.MaxValue * 384);
-            Assert.AreEqual(ushort.MaxValue * 384, receivedBytes);
+            await TestHelper.WaitWhileFalse(() => receivedBytes == ushort.MaxValue * 24, TimeSpan.FromSeconds(5));
+            Assert.AreEqual(ushort.MaxValue * 24, receivedBytes);
         }
     }
 }

--- a/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/Delimiter.cs
+++ b/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/Delimiter.cs
@@ -7,14 +7,16 @@ using NUnit.Framework;
 
 namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
 {
-    public class PrefixLength
+    public class Delimiter
     {
+        private const string DelimiterString = "|";
+
         [Test]
-        public async Task PrefixLengthProtocolReceiveData()
+        public async Task DelimiterProtocolReceiveData()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol()),
-                    new EasyTcpServer(new PrefixLengthProtocol()));
+                    new EasyTcpClient(new DelimiterProtocol(DelimiterString)),
+                    new EasyTcpServer(new DelimiterProtocol(DelimiterString)));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Length);
@@ -25,11 +27,11 @@ namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
         }
 
         [Test]
-        public async Task PrefixLengthProtocolReceiveDataContent()
+        public async Task DelimiterProtocolReceiveDataContent()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol()),
-                    new EasyTcpServer(new PrefixLengthProtocol()));
+                    new EasyTcpClient(new DelimiterProtocol(DelimiterString)),
+                    new EasyTcpServer(new DelimiterProtocol(DelimiterString)));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x=>x == 100));
@@ -41,11 +43,11 @@ namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
 
 
         [Test]
-        public async Task PrefixLengthProtocolReceiveLargeData()
+        public async Task DelimiterProtocolReceiveLargeData()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol(int.MaxValue)),
-                    new EasyTcpServer(new PrefixLengthProtocol(int.MaxValue)));
+                    new EasyTcpClient(new DelimiterProtocol(DelimiterString)),
+                    new EasyTcpServer(new DelimiterProtocol(DelimiterString)));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x=>x == 100));

--- a/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/PlainTcp.cs
+++ b/EasyTcp4/EasyTcp4.Test/EasyTcp/DataTransfer/Protocols/PlainTcp.cs
@@ -7,14 +7,14 @@ using NUnit.Framework;
 
 namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
 {
-    public class PrefixLength
+    public class PlainTcp
     {
         [Test]
-        public async Task PrefixLengthProtocolReceiveData()
+        public async Task PlainTcpProtocolReceiveData()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol()),
-                    new EasyTcpServer(new PrefixLengthProtocol()));
+                    new EasyTcpClient(new PlainTcpProtocol()),
+                    new EasyTcpServer(new PlainTcpProtocol()));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Length);
@@ -25,11 +25,11 @@ namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
         }
 
         [Test]
-        public async Task PrefixLengthProtocolReceiveDataContent()
+        public async Task PlainTcpProtocolReceiveDataContent()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol()),
-                    new EasyTcpServer(new PrefixLengthProtocol()));
+                    new EasyTcpClient(new PlainTcpProtocol()),
+                    new EasyTcpServer(new PlainTcpProtocol()));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x=>x == 100));
@@ -41,11 +41,11 @@ namespace EasyTcp4.Test.EasyTcp.DataTransfer.Protocols
 
 
         [Test]
-        public async Task PrefixLengthProtocolReceiveLargeData()
+        public async Task PlainTcpProtocolReceiveLargeData()
         {
             using var conn = await TestHelper.GetTestConnection(
-                    new EasyTcpClient(new PrefixLengthProtocol(int.MaxValue)),
-                    new EasyTcpServer(new PrefixLengthProtocol(int.MaxValue)));
+                    new EasyTcpClient(new PlainTcpProtocol()),
+                    new EasyTcpServer(new PlainTcpProtocol()));
 
             int receivedBytes = 0;
             conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x=>x == 100));

--- a/EasyTcp4/EasyTcp4.Test/Encryption/Ssl/Protocols/PlainTcp.cs
+++ b/EasyTcp4/EasyTcp4.Test/Encryption/Ssl/Protocols/PlainTcp.cs
@@ -43,5 +43,22 @@ namespace EasyTcp4.Test.Encryption.Ssl.Protocols
             Assert.AreEqual(short.MaxValue * 2, receivedBytes);
         }
 
+        [Test]
+        public async Task PlainSslProtocolReceiveLargeData()
+        {
+            using var certificate = new X509Certificate2("certificate.pfx", "password");
+            using var conn = await TestHelper.GetTestConnection(
+                new EasyTcpClient(new PlainSslProtocol("localhost", true)),
+                new EasyTcpServer(new PlainSslProtocol(certificate)));
+
+            int receivedBytes = 0;
+            conn.Server.OnDataReceive += (_, m) => Interlocked.Add(ref receivedBytes, m.Data.Count(x => x == 100));
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 2).ToArray());
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 2).ToArray());
+            conn.Client.Send(Enumerable.Repeat<byte>(100, ushort.MaxValue * 2).ToArray());
+
+            await TestHelper.WaitWhileFalse(() => receivedBytes == ushort.MaxValue * 6);
+            Assert.AreEqual(ushort.MaxValue * 6, receivedBytes);
+        }
     }
 }


### PR DESCRIPTION
An attempt to reproduce issue #68 , unit tests for all protocols seem to run succesfully.